### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/advantic-au/mqi/compare/v0.2.0...v0.3.0) - 2025-07-23
+
+### Added
+
+- ConnectionEither to hold either ConnectionRef or Connection
+
+### Fixed
+
+- ci warnings
+- memory leak removed
+- release-plz permission
+- ConnectionRef leak of Library
+
+### Other
+
+- MQAI trait
+- latest dependencies
+- latest dependencies
+- *(fix)* feature gate mock on tests
+- Further tightening of the API definition
+- Event Handler mocking
+- Syncpoint and Callback simplify
+- Replaced Conn with AsConnection
+- Safe event handler callback implementation
+- Version assertions
+- Remove mqm_generate
+- doctest fixes
+- Rework ConnectionRef and simplify Conn
+- further refinement of api into modules
+- Moved all handles into a handle module.
+- handles rework
+- Replaced MQMD2 with MQMD
+- mqai src structure refactor
+- QueueManager remove and callback move
+- refactor stat file structure
+- move attribute and constants use locations
+- reorganise code - compile working
+- Major semver
+- docsrs cleanup
+
 ## [0.2.0](https://github.com/advantic-au/mqi/compare/v0.1.0...v0.2.0) - 2025-07-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,39 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ConnectionEither to hold either ConnectionRef or Connection
 
-### Fixed
-
-- ci warnings
-- memory leak removed
-- release-plz permission
-- ConnectionRef leak of Library
-
 ### Other
 
-- MQAI trait
-- latest dependencies
-- latest dependencies
-- *(fix)* feature gate mock on tests
 - Further tightening of the API definition
 - Event Handler mocking
-- Syncpoint and Callback simplify
+- Syncpoint and Callback simplification
 - Replaced Conn with AsConnection
 - Safe event handler callback implementation
 - Version assertions
 - Remove mqm_generate
 - doctest fixes
-- Rework ConnectionRef and simplify Conn
-- further refinement of api into modules
-- Moved all handles into a handle module.
-- handles rework
-- Replaced MQMD2 with MQMD
-- mqai src structure refactor
-- QueueManager remove and callback move
-- refactor stat file structure
-- move attribute and constants use locations
-- reorganise code - compile working
-- Major semver
-- docsrs cleanup
 
 ## [0.2.0](https://github.com/advantic-au/mqi/compare/v0.1.0...v0.2.0) - 2025-07-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mqi"
 description = "Idiomatic IBM® MQ Interface (MQI) and MQ Administration Interface (MQAI) APIs"
 repository = "https://github.com/advantic-au/mqi"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Warren Spits <warren@advantic.au>"]
 license = "Apache-2.0"
 keywords = ["message-queue", "messaging"]


### PR DESCRIPTION



## 🤖 New release

* `mqi`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `mqi` breaking changes

```text
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type ConnectionRef no longer derives Copy, in /tmp/.tmpnpeFt4/mqi/src/connection/function.rs:35

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum mqi::connect_options::MqServerSyntaxError, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:613
  enum mqi::headers::TextEnc, previously in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:211
  enum mqi::PutStringCcsidError, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/bag_item.rs:14
  enum mqi::properties_options::Value, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:138
  enum mqi::properties_options::NameUsage, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:116
  enum mqi::put_options::PropertyAction, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/put_options.rs:38
  enum mqi::FromStringCcsidError, previously in file /tmp/.tmpNDYTaJ/mqi/src/strings.rs:28
  enum mqi::connect_options::Binding, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:247
  enum mqi::headers::HeaderError, previously in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:65
  enum mqi::connect_options::CredentialsSecret, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:285
  enum mqi::connect_options::SuiteB, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:308
  enum mqi::MqInqError, previously in file /tmp/.tmpNDYTaJ/mqi/src/verbs/mod.rs:21
  enum mqi::MqStrError, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqstr.rs:182
  enum mqi::headers::Header, previously in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:90

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/feature_missing.ron

Failed in:
  feature mqm_generate in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function mqi::ascii7_ebcdic, previously in file /tmp/.tmpNDYTaJ/mqi/src/encoding.rs:909
  function mqi::is_ebcdic, previously in file /tmp/.tmpNDYTaJ/mqi/src/encoding.rs:942
  function mqi::stat_reconnection, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/stat.rs:132
  function mqi::ebcdic_ascii7, previously in file /tmp/.tmpNDYTaJ/mqi/src/encoding.rs:903
  function mqi::ccsid_lookup, previously in file /tmp/.tmpNDYTaJ/mqi/src/encoding.rs:929
  function mqi::stat_put, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/stat.rs:107
  function mqi::outcome::tracing_outcome_basic, previously in file /tmp/.tmpNDYTaJ/mqi/src/verbs/outcome.rs:110
  function mqi::outcome::tracing_outcome, previously in file /tmp/.tmpNDYTaJ/mqi/src/verbs/outcome.rs:74
  function mqi::stat_reconnection_error, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/stat.rs:146

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Connection::register_event_handler, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/callback.rs:49
  Object::inq, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/attribute.rs:113
  Object::inq_item, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/attribute.rs:159
  MessageFormat::from_mqmd2, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq_types.rs:137

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod mqi::properties_options, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:1
  mod mqi::raw, previously in file /tmp/.tmpNDYTaJ/mqi/src/handles.rs:24
  mod mqi::outcome, previously in file /tmp/.tmpNDYTaJ/mqi/src/verbs/outcome.rs:1
  mod mqi::subscribe_options, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/subscribe_options.rs:1
  mod mqi::open_options, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/open_options.rs:1
  mod mqi::headers::fmt, previously in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:32
  mod mqi::headers, previously in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:1
  mod mqi::get_options, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/get_options.rs:1
  mod mqi::connect_options, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:1
  mod mqi::put_options, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/put_options.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  MQFMT_AMQP in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:42
  NATIVE_IS_LE in file /tmp/.tmpNDYTaJ/mqi/src/strings.rs:25
  MQFMT_XMIT_Q_HEADER in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:61
  MQFMT_COMMAND_1 in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:45
  MQFMT_DIST_HEADER in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:48
  CONNECT_HAS_NONE in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:29
  MQFMT_IMS in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:51
  MQFMT_PCF in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:54
  CONNECT_HAS_CD in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:38
  MQFMT_RF_HEADER_1 in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:57
  MQFMT_ADMIN in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:40
  MQFMT_WORK_INFO_HEADER in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:60
  MQFMT_CICS in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:44
  MQFMT_DEAD_LETTER_HEADER in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:47
  INQUIRE_ALL_USR in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:15
  MQFMT_EVENT in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:50
  CONNECT_HAS_CNO in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:32
  MQFMT_MD_EXTENSION in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:53
  MQFMT_RF_HEADER in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:56
  CONNECT_HAS_CSP in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:41
  MQFMT_STRING in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:39
  MQFMT_TRIGGER in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:59
  MQFMT_CHANNEL_COMPLETED in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:43
  MQFMT_COMMAND_2 in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:46
  INQUIRE_ALL in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:14
  MQFMT_EMBEDDED_PCF in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:49
  MQFMT_IMS_VAR_STRING in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:52
  CONNECT_HAS_SCO in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:35
  MQFMT_REF_MSG_HEADER in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:55
  MQFMT_NONE in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:38
  MQFMT_RF_HEADER_2 in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:58
  CONNECT_HAS_BNO in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:45

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct mqi::ConnTag, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect.rs:13
  struct mqi::ReconnectionStat, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/stat.rs:197
  struct mqi::raw::Connection, previously in file /tmp/.tmpNDYTaJ/mqi/src/handles.rs:28
  struct mqi::properties_options::PropertyParam, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:24
  struct mqi::SubscribeParam, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/subscribe.rs:24
  struct mqi::open_options::ResObjectString, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/open_options.rs:54
  struct mqi::connect_options::ConnectStructs, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:49
  struct mqi::put_options::Context, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/put_options.rs:12
  struct mqi::ReplyObject, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/execute.rs:19
  struct mqi::Handle, previously in file /tmp/.tmpNDYTaJ/mqi/src/handles.rs:53
  struct mqi::Owned, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/bag.rs:53
  struct mqi::ThreadBlock, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect.rs:106
  struct mqi::SubscribeRequestParam, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/subscribe.rs:31
  struct mqi::Completion, previously in file /tmp/.tmpNDYTaJ/mqi/src/result.rs:11
  struct mqi::MsgPropIter, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties.rs:207
  struct mqi::properties_options::Raw, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:124
  struct mqi::Error, previously in file /tmp/.tmpNDYTaJ/mqi/src/result.rs:82
  struct mqi::headers::EncodedHeader, previously in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:102
  struct mqi::raw::Object, previously in file /tmp/.tmpNDYTaJ/mqi/src/handles.rs:40
  struct mqi::CcsidError, previously in file /tmp/.tmpNDYTaJ/mqi/src/strings.rs:35
  struct mqi::ReconnectionErrorStat, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/stat.rs:205
  struct mqi::connect_options::MqServer, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:185
  struct mqi::CCSID, previously in file /tmp/.tmpNDYTaJ/mqi/src/ccsid.rs:5
  struct mqi::open_options::AlternateUserId, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/open_options.rs:50
  struct mqi::ConnectionId, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect.rs:11
  struct mqi::outcome::MqiOutcome, previously in file /tmp/.tmpNDYTaJ/mqi/src/verbs/outcome.rs:7
  struct mqi::ThreadNone, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect.rs:96
  struct mqi::properties_options::PropertyState, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:18
  struct mqi::ExecuteParam, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/execute.rs:9
  struct mqi::headers::HeaderIter, previously in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:629
  struct mqi::Bag, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/bag.rs:73
  struct mqi::connect_options::Tls, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:300
  struct mqi::Filter, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/filter.rs:6
  struct mqi::raw::Message, previously in file /tmp/.tmpNDYTaJ/mqi/src/handles.rs:34
  struct mqi::connect_options::InitialKeySecret, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:279
  struct mqi::open_options::SelectionString, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/open_options.rs:44
  struct mqi::AsyncPutStat, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/stat.rs:183
  struct mqi::open_options::ObjectString, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/open_options.rs:47
  struct mqi::SubscribeState, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/subscribe.rs:18
  struct mqi::Embedded, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/bag.rs:55
  struct mqi::AdminObject, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/execute.rs:21
  struct mqi::OpenParamOption, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/object.rs:6
  struct mqi::properties_options::Metadata, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:105
  struct mqi::properties_options::Null, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:113
  struct mqi::properties_options::Attributes, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:100
  struct mqi::connect_options::Ccdt, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:182
  struct mqi::connect_options::ConnectStructFlags, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:27
  struct mqi::ThreadNoBlock, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect.rs:101
  struct mqi::properties_options::Name, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:359
  struct mqi::StringCcsid, previously in file /tmp/.tmpNDYTaJ/mqi/src/strings.rs:9
  struct mqi::OptionsBag, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/execute.rs:17

--- failure struct_must_use_added: struct #[must_use] added ---

Description:
A struct is now #[must_use]. Downstream crates that did not use its value will get a compiler lint.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_must_use_added.ron

Failed in:
  struct Properties in /tmp/.tmpnpeFt4/mqi/src/properties/function.rs:26
  struct ConnectionRef in /tmp/.tmpnpeFt4/mqi/src/connection/function.rs:35
  struct Subscription in /tmp/.tmpnpeFt4/mqi/src/subscription/function.rs:19

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_missing.ron

Failed in:
  method put_bag_extract of trait PutAttr, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/put.rs:140

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_missing.ron

Failed in:
  trait mqi::Buffer, previously in file /tmp/.tmpNDYTaJ/mqi/src/traits.rs:49
  trait mqi::headers::ChainedHeader, previously in file /tmp/.tmpNDYTaJ/mqi/src/headers.rs:173
  trait mqi::QueueManagerAdmin, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/execute.rs:57
  trait mqi::OpenOption, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/object.rs:29
  trait mqi::ConnectValue, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect.rs:142
  trait mqi::SubscribeAttr, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/subscribe.rs:84
  trait mqi::BagDrop, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/bag.rs:11
  trait mqi::OpenAttr, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/object.rs:50
  trait mqi::ResultCompExt, previously in file /tmp/.tmpNDYTaJ/mqi/src/result.rs:92
  trait mqi::WriteRaw, previously in file /tmp/.tmpNDYTaJ/mqi/src/traits.rs:25
  trait mqi::properties_options::SetProperty, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:62
  trait mqi::SubscribeRequestOption, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/subscribe.rs:104
  trait mqi::Threading, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect.rs:50
  trait mqi::SubscribeOption, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/subscribe.rs:100
  trait mqi::Secret, previously in file /tmp/.tmpNDYTaJ/mqi/src/traits.rs:5
  trait mqi::OpenValue, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/object.rs:37
  trait mqi::ReadRaw, previously in file /tmp/.tmpNDYTaJ/mqi/src/traits.rs:36
  trait mqi::properties_options::PropertyAttr, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:55
  trait mqi::WithMqError, previously in file /tmp/.tmpNDYTaJ/mqi/src/result.rs:97
  trait mqi::MQMD, previously in file /tmp/.tmpNDYTaJ/mqi/src/traits.rs:12
  trait mqi::BagItemPut, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/bag_item.rs:21
  trait mqi::ConnectAttr, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect.rs:150
  trait mqi::properties_options::SetPropertyAttr, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:67
  trait mqi::BagItemGet, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/bag_item.rs:28
  trait mqi::connect_options::ConnectOption, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect_options.rs:68
  trait mqi::QueueManager, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/queue_manager.rs:12
  trait mqi::Conn, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/connect.rs:16
  trait mqi::InqSelect, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/bag.rs:17
  trait mqi::ExecuteOption, previously in file /tmp/.tmpNDYTaJ/mqi/src/mqai/execute.rs:53
  trait mqi::ResultCompErrExt, previously in file /tmp/.tmpNDYTaJ/mqi/src/result.rs:108
  trait mqi::SubscribeValue, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/subscribe.rs:75
  trait mqi::RawHandle, previously in file /tmp/.tmpNDYTaJ/mqi/src/handles.rs:20
  trait mqi::EncodedString, previously in file /tmp/.tmpNDYTaJ/mqi/src/strings.rs:174
  trait mqi::properties_options::PropertyValue, previously in file /tmp/.tmpNDYTaJ/mqi/src/mq/properties_options.rs:36
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/advantic-au/mqi/compare/v0.2.0...v0.3.0) - 2025-07-23

### Added

- ConnectionEither to hold either ConnectionRef or Connection

### Fixed

- ci warnings
- memory leak removed
- release-plz permission
- ConnectionRef leak of Library

### Other

- MQAI trait
- latest dependencies
- latest dependencies
- *(fix)* feature gate mock on tests
- Further tightening of the API definition
- Event Handler mocking
- Syncpoint and Callback simplify
- Replaced Conn with AsConnection
- Safe event handler callback implementation
- Version assertions
- Remove mqm_generate
- doctest fixes
- Rework ConnectionRef and simplify Conn
- further refinement of api into modules
- Moved all handles into a handle module.
- handles rework
- Replaced MQMD2 with MQMD
- mqai src structure refactor
- QueueManager remove and callback move
- refactor stat file structure
- move attribute and constants use locations
- reorganise code - compile working
- Major semver
- docsrs cleanup
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).