### PR TITLE
chore: release v0.3.1

### DIFF
--- a/.github/workflows/semver-check.yml
+++ b/.github/workflows/semver-check.yml
@@ -1,0 +1,59 @@
+name: Semver Compatibility Check
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  semver-check:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      with:
+        toolchain: stable
+
+    - uses: taiki-e/install-action@c07504cae06f832dc8de08911c9a9c5cddb0d2d3 # v2.56.13
+      with:
+        tool: cargo-semver-checks
+
+    - name: Get merge base
+      id: merge-base
+      env:
+        GITHUB_BASE_REF: ${{ github.base_ref }}
+      run: echo "sha=$(git merge-base origin/${GITHUB_BASE_REF} HEAD)" >> $GITHUB_OUTPUT
+
+    - name: Check semver compatibility
+      id: semver
+      run: |
+        set +e
+        output=$(cargo semver-checks check-release --baseline-rev ${MERGE_BASE_SHA} 2>&1)
+        exit_code=$?
+        echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
+        echo "output<<EOF" >> $GITHUB_OUTPUT
+        echo "$output" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+      env:
+        MERGE_BASE_SHA: ${{ steps.merge-base.outputs.sha }}
+
+    - name: Comment PR
+      uses: peter-evans/create-or-update-comment@978effe9a5f7321b0c77cf174ee7bce90f03ac61
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          ## Semver Compatibility Check ${{ steps.semver.outputs.exit_code == '0' && '✅ PASS' || '❌ FAIL' }}
+          
+          ```
+          ${{ steps.semver.outputs.output }}
+          ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/advantic-au/mqi/compare/v0.3.0...v0.3.1) - 2025-08-08
+
+### Other
+
+- semver adjustments
+
 ## [0.3.0](https://github.com/advantic-au/mqi/compare/v0.2.0...v0.3.0) - 2025-07-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mqi"
 description = "Idiomatic IBM® MQ Interface (MQI) and MQ Administration Interface (MQAI) APIs"
 repository = "https://github.com/advantic-au/mqi"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Warren Spits <warren@advantic.au>"]
 license = "Apache-2.0"
 keywords = ["message-queue", "messaging"]


### PR DESCRIPTION



## 🤖 New release

* `mqi`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/advantic-au/mqi/compare/v0.3.0...v0.3.1) - 2025-08-08

### Other

- semver adjustments
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).