### PR TITLE
chore: release v0.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vscode
 /mutants.out
 /mutants.out.old
+/.aider.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/advantic-au/mqi/compare/v0.3.0...v0.3.1) - 2025-08-12
+
+### Other
+
+- Add .aider.* gitignore
+- MQ exits API
+- semver adjustments
+
 ## [0.3.0](https://github.com/advantic-au/mqi/compare/v0.2.0...v0.3.0) - 2025-07-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mqi"
 description = "Idiomatic IBM® MQ Interface (MQI) and MQ Administration Interface (MQAI) APIs"
 repository = "https://github.com/advantic-au/mqi"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Warren Spits <warren@advantic.au>"]
 license = "Apache-2.0"
 keywords = ["message-queue", "messaging"]


### PR DESCRIPTION



## 🤖 New release

* `mqi`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/advantic-au/mqi/compare/v0.3.0...v0.3.1) - 2025-08-12

### Other

- Add .aider.* gitignore
- MQ exits API
- semver adjustments
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).