### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/advantic-au/mqi/compare/v0.3.0...v0.3.1) - 2026-02-16
+
+### Other
+
+- *(deps)* bump actions/upload-artifact from 5 to 6 ([#149](https://github.com/advantic-au/mqi/pull/149))
+- dependabot updates and cooldown
+- *(deps)* bump peter-evans/create-or-update-comment
+- IBM MQ 9.4.5
+- Updated to latest versions
+- *(deps)* update mockall requirement from 0.13.1 to 0.14.0
+- Add .aider.* gitignore
+- MQ exits API
+- semver adjustments
+
 ## [0.3.0](https://github.com/advantic-au/mqi/compare/v0.2.0...v0.3.0) - 2025-07-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mqi"
 description = "Idiomatic IBM® MQ Interface (MQI) and MQ Administration Interface (MQAI) APIs"
 repository = "https://github.com/advantic-au/mqi"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Warren Spits <warren@advantic.au>"]
 license = "Apache-2.0"
 keywords = ["message-queue", "messaging"]


### PR DESCRIPTION



## 🤖 New release

* `mqi`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/advantic-au/mqi/compare/v0.3.0...v0.3.1) - 2026-02-16

### Other

- *(deps)* bump actions/upload-artifact from 5 to 6 ([#149](https://github.com/advantic-au/mqi/pull/149))
- dependabot updates and cooldown
- *(deps)* bump peter-evans/create-or-update-comment
- IBM MQ 9.4.5
- Updated to latest versions
- *(deps)* update mockall requirement from 0.13.1 to 0.14.0
- Add .aider.* gitignore
- MQ exits API
- semver adjustments
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).